### PR TITLE
Fix ReferenceError on Node 0.10.x

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "plugins": ["add-module-exports"],
+  "plugins": ["add-module-exports", "transform-runtime"],
   "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel-core": "^6.1.21",
     "babel-plugin-add-module-exports": "^0.1.1",
     "babel-plugin-espower": "^2.0.0",
+    "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-es2015": "^6.1.18",
     "codecov.io": "^0.1.6",
     "esdoc": "^0.4.1",
@@ -58,6 +59,7 @@
     "watch:test": "mocha --watch test/{**/,}*spec.js"
   },
   "dependencies": {
+    "babel-runtime": "^6.6.1",
     "os-homedir": "^1.0.1"
   }
 }


### PR DESCRIPTION
- Raises `ReferenceError: Symbol is not defined`
- Codes transformed babel includes `Symbol`, but Node 0.10.x does not have it...
